### PR TITLE
make at_hash optional to comply with OIDC spec

### DIFF
--- a/Web/Modules/OIDC.php
+++ b/Web/Modules/OIDC.php
@@ -586,7 +586,13 @@ class OIDC extends WebModule
 	{
 		// Get decoded ID token properties
 		$id_token_dec = JWT::decodeToken($id_token);
-		$at_hash = $id_token_dec['body']['at_hash'];
+		$at_hash = $id_token_dec['body']['at_hash'] ?? null;
+
+		if (is_null($at_hash)) {
+			# at_hash is optional
+			# OpenID Connect Core 1.0 §3.1.3.8. - Access Token Validation
+			return true;
+		}
 
 		// Compute at hash
 		$digit = hash('sha256', $access_token, true);


### PR DESCRIPTION
Ref: [OpenID Connect Core 1.0 §3.1.3.8. - Access Token Validation](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowTokenValidation)

Discovered using Nextcloud as a provider (oidc 1.9.0), because after the login on Nextcloud Bacularis thrown this exception: `[Warning] Undefined array key "at_hash" (@line 589 in file /var/www/bacularis-app/protected/vendor/bacularis/bacularis-web/Web/Modules/OIDC.php).`